### PR TITLE
Filename in window title

### DIFF
--- a/G2 Gui/defs.h
+++ b/G2 Gui/defs.h
@@ -37,6 +37,8 @@
 #define TARGET_FRAME_BUFF_HEIGHT             (1440)
 #define GLOBAL_GUI_SCALE                     (2)
 
+#define WINDOW_TITLE                         "G2 Editor"
+
 #define NUM_VARIATIONS                       (10) // 10 variations per patch, but only fist 8 presented on the GUI
 #define NUM_GUI_VARIATIONS                   (8)
 #define NUM_MORPHS                           (8)  // Not sure if we can go higher with this, so remember to check

--- a/G2 Gui/graphics.cpp
+++ b/G2 Gui/graphics.cpp
@@ -92,6 +92,15 @@ void window_close_callback(GLFWwindow * window) {
     glfwPostEmptyEvent();
 }
 
+void set_window_title(const char * title) {
+    const char * filename = strrchr(title, '/');
+    char newTitle [100];
+    strcpy(newTitle,WINDOW_TITLE);
+    strcat(newTitle," - ");
+    strcat(newTitle,filename + 1);
+    glfwSetWindowTitle(gWindow, newTitle);
+}
+
 void error_callback(int error, const char * description) {
     LOG_ERROR("GLFW error [%d]: %s\n", error, description);
 }
@@ -238,7 +247,7 @@ void init_graphics(void) {
     windowWidth  = TARGET_FRAME_BUFF_WIDTH / xScale;
     windowHeight = TARGET_FRAME_BUFF_HEIGHT / yScale;
 
-    gWindow = glfwCreateWindow(windowWidth, windowHeight, "G2 Editor", NULL, NULL);
+    gWindow = glfwCreateWindow(windowWidth, windowHeight, WINDOW_TITLE, NULL, NULL);
 
     if (!gWindow) {
         glfwTerminate();
@@ -341,6 +350,7 @@ void read_file_into_memory_and_process(const char * filepath) {
     } else {
         LOG_WARNING("CRC check failed\n");
     }
+        
     free(buff);
     fclose(file);
 }
@@ -350,8 +360,10 @@ void check_action_flags(void) {
         char * path = open_file_dialogue();
 
         if (path != NULL) {
-            LOG_INFO("Selected file: %s\n", path);
+            LOG_INFO("\n\nSelected file: %s\n", path);
 
+            set_window_title(path);
+            
             read_file_into_memory_and_process(path);
 
             free((void *)path);


### PR DESCRIPTION
After loading a patch file, the name of the file is added to the window title.